### PR TITLE
Small change to bold and italics toggle.

### DIFF
--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -86,7 +86,7 @@ function wrapSelection(startPattern, endPattern?) {
             });
         }
         else {
-            let newPosition = new Position(editor.selection.active.line, editor.selection.active.character + 2)
+            let newPosition = new Position(editor.selection.active.line, editor.selection.active.character + endPattern.length)
             editor.selection = new Selection(newPosition, newPosition);
         }
     }

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -121,10 +121,18 @@ function atEndOfWrappedWord(startPattern, endPattern): boolean {
     if (selection.isEmpty) {
         let position = selection.active;
         
-        selection = new Selection(new Position(position.line, position.character - startPattern.length), position);
+        let startPositionCharacter = position.character - startPattern.length;
+        let endPositionCharacter = position.character + endPattern.length;
+        
+        // If cursor on empty line:
+        if (startPositionCharacter < 0) {
+            startPositionCharacter = 0;
+        }
+        
+        selection = new Selection(new Position(position.line, startPositionCharacter), position);
         let leftText = editor.document.getText(selection);
         
-        selection = new Selection(new Position(position.line, position.character + endPattern.length), position);
+        selection = new Selection(new Position(position.line, endPositionCharacter), position);
         let rightText = editor.document.getText(selection);
         
         if (leftText != startPattern && rightText == endPattern) {


### PR DESCRIPTION
I wanted the bold and italics toggles to work more like the way they do in Google Docs where the user can toggle bold to "on", type the word or words they want, then toggle bold to "off" to keep typing in normal style.

The way I accomplished this in the code is to have the cursor jump to outside of the "*" or "**" in the markdown if the user hits the keyboard shortcut again while the cursor is at the end of the bold text but still inside of the asterisks.

In other words, if the user hits `Ctrl+B` when the cursor is at:

    **bold text|**

the cursor will jump two places to the right:

    **bold text**|

and the user can keep typing as normal without having to hit the "end" key or use the mouse.