### PR TITLE
Numbered List Continuation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,10 @@ export function activate(context: ExtensionContext) {
             {
                 beforeText: /^> .+/,
                 action: { indentAction: IndentAction.None, appendText: '> ' }
+            },
+            {
+                beforeText: /^[0-9][.] .+/,
+                action: { indentAction: IndentAction.None, appendText: '1. ' }
             }
         ]
     });

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -121,18 +121,18 @@ function atEndOfWrappedWord(startPattern, endPattern): boolean {
     if (selection.isEmpty) {
         let position = selection.active;
         
-        let startPositionCharacter = position.character - startPattern.length;
-        let endPositionCharacter = position.character + endPattern.length;
+        let startCharacterPosition = position.character - startPattern.length;
+        let endCharacterPosition = position.character + endPattern.length;
         
         // If cursor on empty line:
-        if (startPositionCharacter < 0) {
-            startPositionCharacter = 0;
+        if (startCharacterPosition < 0) {
+            startCharacterPosition = 0;
         }
         
-        selection = new Selection(new Position(position.line, startPositionCharacter), position);
+        selection = new Selection(new Position(position.line, startCharacterPosition), position);
         let leftText = editor.document.getText(selection);
         
-        selection = new Selection(new Position(position.line, endPositionCharacter), position);
+        selection = new Selection(new Position(position.line, endCharacterPosition), position);
         let rightText = editor.document.getText(selection);
         
         if (leftText != startPattern && rightText == endPattern) {


### PR DESCRIPTION
I changed a few variable names to make more sense but I also added an extra "continuation" character for numbered lists so that when you hit the `Enter` key when the cursor is at the end of an item of a numbered list, it will continue that numbered list.

    1. This is a numbered list |     //> hit enter here
    1.                               //> new numbered list item added automatically.