### PR TITLE
toLowerCase() causes broken links in TOC for non-Latin symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ All you need for Markdown (keyboard shortcuts, table of contents, auto preview a
 | `markdown.extension.toc.unorderedList.marker`      | `-`       | Use `-`, `*` or `+` in the table of contents (for unordered list)                  |
 | `markdown.extension.toc.orderedList`               | `false`   | Use ordered list in the table of contents.                                         |
 | `markdown.extension.toc.plaintext`                 | `false`   | Just plain text.                                                                   |
-| `markdown.extension.toc.updateOnSave`              | `false`   | Automatically update the table of contents on save.                                |
+| `markdown.extension.toc.updateOnSave`              | `true`    | Automatically update the table of contents on save.                                |
 | `markdown.extension.toc.encodeUri`                 | `true`    | You might want to set this to `false` if you have some non-Latin characters in TOC |
+| `markdown.extension.toc.toLowerCase`               | `true`    | Prevent non-Latin symbols from lowercasing                                         |
 | `markdown.extension.preview.autoShowPreviewToSide` | `false`   | Automatically show preview when opening a Markdown file.                           |
 | `markdown.extension.orderedList.marker`            | `ordered` | Or `one`: always use `1.` as ordered list marker                                   |
 | `markdown.extension.italic.indicator`              | `*`       | Use `*` or `_` to wrap italic text                                                 |

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ All you need for Markdown (keyboard shortcuts, table of contents, auto preview a
   - Tip: in normal mode, `**word|**` -> `**word**|` (<kbd>ctrl</kbd> + <kbd>b</kbd>)
   - *Quick styling mode*: toggle bold/italic without selecting words
 - **Table of contents** (No additional annoying tags like `<!-- TOC -->`)
+  - To make TOC compatible with GitHub, you might need to set options `encodeUri` and `toLowerCase` to `false`
 - **Outline view** in explorer panel
 - **Automatically show preview** when opening a Markdown file (Disabled by default)
 - **Print Markdown to HTML**

--- a/package.json
+++ b/package.json
@@ -154,6 +154,11 @@
                     "default": true,
                     "description": "In VS Code preview, the anchors of headings are encoded. But if you want the generated TOC to work on GitHub etc., you might need to set this to `false`"
                 },
+                "markdown.extension.toc.toLowerCase": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Prevent non-Latin symbols from lowercasing"
+                },
                 "markdown.extension.preview.autoShowPreviewToSide": {
                     "type": "boolean",
                     "default": false,

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,7 +28,6 @@ export function log(msg: string, obj?) {
 
 export function slugify(heading: string) {
     let slug = heading.trim()
-        .toLowerCase()
         .replace(/[\]\[\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~\`]/g, '')
         .replace(/\s+/g, '-')
         .replace(/^\-+/, '')

--- a/src/util.ts
+++ b/src/util.ts
@@ -32,5 +32,9 @@ export function slugify(heading: string) {
         .replace(/\s+/g, '-')
         .replace(/^\-+/, '')
         .replace(/\-+$/, '');
+    if (workspace.getConfiguration('markdown.extension.toc').get<boolean>('toLowerCase')) {
+        slug = slug.toLowerCase();
+    }
+    
     return workspace.getConfiguration('markdown.extension.toc').get<boolean>('encodeUri') ? encodeURI(slug) : slug;
 }

--- a/test/toc.test.ts
+++ b/test/toc.test.ts
@@ -45,9 +45,9 @@ suite("TOC.", () => {
                 '',
                 '# Section 2',
                 '',
-                '- [Section 1](#Section-1)',
-                '    - [Section 1.1](#Section-11)',
-                '- [Section 2](#Section-2)'
+                '- [Section 1](#section-1)',
+                '    - [Section 1.1](#section-11)',
+                '- [Section 2](#section-2)'
             ],
             new Selection(8, 25, 8, 25)).then(done, done);
     });
@@ -68,9 +68,9 @@ suite("TOC.", () => {
                 '',
                 '## Section 2.1',
                 '',
-                '- [Section 1](#Section-1)',
-                '    - [Section 1.1](#Section-11)',
-                '- [Section 2](#Section-2)'
+                '- [Section 1](#section-1)',
+                '    - [Section 1.1](#section-11)',
+                '- [Section 2](#section-2)'
             ],
             new Selection(0, 0, 0, 0),
             [
@@ -82,10 +82,10 @@ suite("TOC.", () => {
                 '',
                 '## Section 2.1',
                 '',
-                '- [Section 1](#Section-1)',
-                '    - [Section 1.1](#Section-11)',
-                '- [Section 2](#Section-2)',
-                '    - [Section 2.1](#Section-21)'
+                '- [Section 1](#section-1)',
+                '    - [Section 1.1](#section-11)',
+                '- [Section 2](#section-2)',
+                '    - [Section 2.1](#section-21)'
             ],
             new Selection(0, 0, 0, 0)).then(done, done);
     });
@@ -134,10 +134,10 @@ suite("TOC.", () => {
                 '',
                 '#### Section 2.1.1.1',
                 '',
-                '- [Section 1.1](#Section-11)',
-                '    - [Section 1.1.1](#Section-111)',
-                '- [Section 2.1](#Section-21)',
-                '    - [Section 2.1.1](#Section-211)',
+                '- [Section 1.1](#section-11)',
+                '    - [Section 1.1.1](#section-111)',
+                '- [Section 2.1](#section-21)',
+                '    - [Section 2.1.1](#section-211)',
             ],
             new Selection(19, 35, 19, 35)).then(done, done);
     });
@@ -162,10 +162,10 @@ suite("TOC.", () => {
                 '',
                 '## Section 2.1',
                 '',
-                '- [Section 1.1](#Section-11)',
-                '    - [Section 1.1.1](#Section-111)',
-                '- [Section 2.1](#Section-21)',
-                '    - [Section 2.1.1](#Section-211)',
+                '- [Section 1.1](#section-11)',
+                '    - [Section 1.1.1](#section-111)',
+                '- [Section 2.1](#section-21)',
+                '    - [Section 2.1.1](#section-211)',
             ],
             new Selection(0, 0, 0, 0),
             [
@@ -181,9 +181,9 @@ suite("TOC.", () => {
                 '',
                 '## Section 2.1',
                 '',
-                '- [Section 1.1](#Section-11)',
-                '    - [Section 1.1.1](#Section-111)',
-                '- [Section 2.1](#Section-21)'
+                '- [Section 1.1](#section-11)',
+                '    - [Section 1.1.1](#section-111)',
+                '- [Section 2.1](#section-21)'
             ],
             new Selection(0, 0, 0, 0)).then(done, done);
     });
@@ -212,9 +212,9 @@ suite("TOC.", () => {
                 '',
                 '# Section 2',
                 '',
-                '- [Section 中文](#Section-%E4%B8%AD%E6%96%87)',
-                '    - [Section 1.1](#Section-11)',
-                '- [Section 2](#Section-2)'
+                '- [Section 中文](#section-%E4%B8%AD%E6%96%87)',
+                '    - [Section 1.1](#section-11)',
+                '- [Section 2](#section-2)'
             ],
             new Selection(8, 25, 8, 25)).then(done, done);
     });
@@ -264,8 +264,8 @@ suite("TOC.", () => {
                 'Section 1.1',
                 '---',
                 '',
-                '- [Section 1](#Section-1)',
-                '    - [Section 1.1](#Section-11)'
+                '- [Section 1](#section-1)',
+                '    - [Section 1.1](#section-11)'
             ],
             new Selection(7, 32, 7, 32)).then(done, done);
     });

--- a/test/toc.test.ts
+++ b/test/toc.test.ts
@@ -45,9 +45,9 @@ suite("TOC.", () => {
                 '',
                 '# Section 2',
                 '',
-                '- [Section 1](#section-1)',
-                '    - [Section 1.1](#section-11)',
-                '- [Section 2](#section-2)'
+                '- [Section 1](#Section-1)',
+                '    - [Section 1.1](#Section-11)',
+                '- [Section 2](#Section-2)'
             ],
             new Selection(8, 25, 8, 25)).then(done, done);
     });
@@ -68,9 +68,9 @@ suite("TOC.", () => {
                 '',
                 '## Section 2.1',
                 '',
-                '- [Section 1](#section-1)',
-                '    - [Section 1.1](#section-11)',
-                '- [Section 2](#section-2)'
+                '- [Section 1](#Section-1)',
+                '    - [Section 1.1](#Section-11)',
+                '- [Section 2](#Section-2)'
             ],
             new Selection(0, 0, 0, 0),
             [
@@ -82,10 +82,10 @@ suite("TOC.", () => {
                 '',
                 '## Section 2.1',
                 '',
-                '- [Section 1](#section-1)',
-                '    - [Section 1.1](#section-11)',
-                '- [Section 2](#section-2)',
-                '    - [Section 2.1](#section-21)'
+                '- [Section 1](#Section-1)',
+                '    - [Section 1.1](#Section-11)',
+                '- [Section 2](#Section-2)',
+                '    - [Section 2.1](#Section-21)'
             ],
             new Selection(0, 0, 0, 0)).then(done, done);
     });
@@ -134,10 +134,10 @@ suite("TOC.", () => {
                 '',
                 '#### Section 2.1.1.1',
                 '',
-                '- [Section 1.1](#section-11)',
-                '    - [Section 1.1.1](#section-111)',
-                '- [Section 2.1](#section-21)',
-                '    - [Section 2.1.1](#section-211)',
+                '- [Section 1.1](#Section-11)',
+                '    - [Section 1.1.1](#Section-111)',
+                '- [Section 2.1](#Section-21)',
+                '    - [Section 2.1.1](#Section-211)',
             ],
             new Selection(19, 35, 19, 35)).then(done, done);
     });
@@ -162,10 +162,10 @@ suite("TOC.", () => {
                 '',
                 '## Section 2.1',
                 '',
-                '- [Section 1.1](#section-11)',
-                '    - [Section 1.1.1](#section-111)',
-                '- [Section 2.1](#section-21)',
-                '    - [Section 2.1.1](#section-211)',
+                '- [Section 1.1](#Section-11)',
+                '    - [Section 1.1.1](#Section-111)',
+                '- [Section 2.1](#Section-21)',
+                '    - [Section 2.1.1](#Section-211)',
             ],
             new Selection(0, 0, 0, 0),
             [
@@ -181,9 +181,9 @@ suite("TOC.", () => {
                 '',
                 '## Section 2.1',
                 '',
-                '- [Section 1.1](#section-11)',
-                '    - [Section 1.1.1](#section-111)',
-                '- [Section 2.1](#section-21)'
+                '- [Section 1.1](#Section-11)',
+                '    - [Section 1.1.1](#Section-111)',
+                '- [Section 2.1](#Section-21)'
             ],
             new Selection(0, 0, 0, 0)).then(done, done);
     });
@@ -212,9 +212,9 @@ suite("TOC.", () => {
                 '',
                 '# Section 2',
                 '',
-                '- [Section 中文](#section-%E4%B8%AD%E6%96%87)',
-                '    - [Section 1.1](#section-11)',
-                '- [Section 2](#section-2)'
+                '- [Section 中文](#Section-%E4%B8%AD%E6%96%87)',
+                '    - [Section 1.1](#Section-11)',
+                '- [Section 2](#Section-2)'
             ],
             new Selection(8, 25, 8, 25)).then(done, done);
     });
@@ -264,8 +264,8 @@ suite("TOC.", () => {
                 'Section 1.1',
                 '---',
                 '',
-                '- [Section 1](#section-1)',
-                '    - [Section 1.1](#section-11)'
+                '- [Section 1](#Section-1)',
+                '    - [Section 1.1](#Section-11)'
             ],
             new Selection(7, 32, 7, 32)).then(done, done);
     });


### PR DESCRIPTION
For example, string "Работа с переменными" becomes link "#работа-с-переменными", which doesn't work. In this case, correct link must be "#Работа-с-переменными" (capital letter at the beginning of the first word).