### PR TITLE
Adapted VSCode task format from v0.1.0 to 2.0.0

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,23 +8,30 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "npm",
 
-    // we want to run npm
-    "command": "npm",
+            // the command is a  shell script
+            "type": "shell",
 
-    // the command is a shell script
-    "isShellCommand": true,
+            // we want to run npm
+            "command": "npm",
 
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
+            // we run the custom script "compile" as defined in package.json
+            "args": ["run", "compile", "--loglevel", "silent"],
 
-    // we run the custom script "compile" as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
+            // show the output window only if unrecognized errors occur.
+            "showOutput": "silent",
 
-    // The tsc compiler is started in watching mode
-    "isWatching": true,
+            // The tsc compiler is started in watching mode
+            "isWatching": true,
 
-    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+            // use the standard tsc in watch mode problem matcher to find compile problems in the output.
+            "problemMatcher": [
+                "$tsc-watch"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
I had issues with building the project in VSCode with the tasks in v0.1.0. No content change, but just migration to the new format.