### PR TITLE
Reworked table formatting to handle indented tables

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,23 +8,30 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "npm",
 
-    // we want to run npm
-    "command": "npm",
+            // the command is a  shell script
+            "type": "shell",
 
-    // the command is a shell script
-    "isShellCommand": true,
+            // we want to run npm
+            "command": "npm",
 
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
+            // we run the custom script "compile" as defined in package.json
+            "args": ["run", "compile", "--loglevel", "silent"],
 
-    // we run the custom script "compile" as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
+            // show the output window only if unrecognized errors occur.
+            "showOutput": "silent",
 
-    // The tsc compiler is started in watching mode
-    "isWatching": true,
+            // The tsc compiler is started in watching mode
+            "isWatching": true,
 
-    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+            // use the standard tsc in watch mode problem matcher to find compile problems in the output.
+            "problemMatcher": [
+                "$tsc-watch"
+            ]
+        }
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -203,6 +203,11 @@
                     "default": true,
                     "description": "Enable GFM table formatter"
                 },
+                "markdown.extension.tableFormatter.normalizeIndentation": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Normalize table indentation to closest multiple of configured tabSize"
+                },
                 "markdown.extension.print.absoluteImgPath": {
                     "type": "boolean",
                     "default": true,

--- a/package.json
+++ b/package.json
@@ -102,6 +102,16 @@
                 "when": "editorTextFocus && !editorHasSelection && editorLangId == markdown && !suggestWidgetVisible"
             },
             {
+                "command": "markdown.extension.onMoveLineUp",
+                "key": "alt+up",
+                "when": "editorTextFocus && !editorHasSelection && editorLangId == markdown && !suggestWidgetVisible"
+            },
+            {
+                "command": "markdown.extension.onMoveLineDown",
+                "key": "alt+down",
+                "when": "editorTextFocus && !editorHasSelection && editorLangId == markdown && !suggestWidgetVisible"
+            },
+            {
                 "command": "markdown.extension.checkTaskList",
                 "key": "alt+c",
                 "when": "editorTextFocus && editorLangId == markdown"

--- a/src/listEditing.ts
+++ b/src/listEditing.ts
@@ -177,6 +177,8 @@ function fixMarker(editor: vscode.TextEditor, line: number) {
             let marker = matches[2];
             let fixedMarker = lookUpwardForMarker(editor.document, line, leadingSpace);
 
+            if (Number(marker) === fixedMarker) return;
+
             return editor.edit(editBuilder => {
                 editBuilder.replace(new Range(line, leadingSpace.length, line, leadingSpace.length + marker.length), String(fixedMarker));
             });

--- a/src/tableFormatter.ts
+++ b/src/tableFormatter.ts
@@ -41,20 +41,22 @@ class MarkdownDocumentFormatter implements DocumentFormattingEditProvider {
     }
 
     /**
-     * Get the normalized indentation of a table as multiple of the configured `tabSize`.
-     * The indentation is only read from the first line and normalized to the closest tab stop.
+     * Return the indentation of a table as a string of spaces by reading it from the first line.
+     * In case of `markdown.extension.table.normalizeIdentation` is `enabled` it is rounded to the closest multiple of
+     * the configured `tabSize`.
      */
-    private getNormalizedIndentation(text: string, options: FormattingOptions) {
+    private getTableIndentation(text: string, options: FormattingOptions) {
+        let doNormalize = workspace.getConfiguration('markdown.extension.tableFormatter').get<boolean>('normalizeIndentation')
         let indentRegex = new RegExp(/^(\s*)\S/u)
         let match = text.match(indentRegex)
-        let indent = match[1].length
-        let tabStops = Math.round(indent / options.tabSize)
-
-        return " ".repeat(options.tabSize * tabStops)
+        let spacesInFirstLine = match[1].length
+        let tabStops = Math.round(spacesInFirstLine / options.tabSize)
+        let spaces = doNormalize ? " ".repeat(options.tabSize * tabStops) : " ".repeat(spacesInFirstLine)
+        return spaces
     }
 
     private formatTable(text: string, doc: TextDocument, options: FormattingOptions) {
-        let indentation = this.getNormalizedIndentation(text, options)
+        let indentation = this.getTableIndentation(text, options)
 
         let rows = []
         let rowsNoIndentPattern = new RegExp(/^\s*(\S.*)$/gum)

--- a/src/tableFormatter.ts
+++ b/src/tableFormatter.ts
@@ -16,7 +16,7 @@ class MarkdownDocumentFormatter implements DocumentFormattingEditProvider {
         let tables = this.detectTables(document.getText());
         if (tables !== null) {
             tables.forEach(table => {
-                edits.push(new TextEdit(this.getRange(document, table), this.formatTable(table, document)));
+                edits.push(new TextEdit(this.getRange(document, table), this.formatTable(table, document, options)));
             });
             return edits;
         } else {
@@ -27,7 +27,8 @@ class MarkdownDocumentFormatter implements DocumentFormattingEditProvider {
     private detectTables(text: string) {
         const lineBreak = '\\r?\\n';
         const contentLine = '\\|?.*\\|.*\\|?';
-        const hyphenLine = '\\|?[ :]*[-]{3,}[- :\\|]*\\|?';
+        const hyphenLine = '[ \\t]*\\|?([ :]*[-]{3,}[ :]*\\|)([ :]*[-]{3,}[ :]*\\|?)+[ \\t]*'
+
         const tableRegex = new RegExp(contentLine + lineBreak + hyphenLine + '(?:' + lineBreak + contentLine + ')*', 'g');
         return text.match(tableRegex);
     }
@@ -39,61 +40,77 @@ class MarkdownDocumentFormatter implements DocumentFormattingEditProvider {
         return new Range(start, end);
     }
 
-    private formatTable(text: string, doc: TextDocument) {
-        let rows = text.split(/\r?\n/g);
-        let content = rows.map(row => {
-            // Escape 
-            // 1. replace (`,`) pair with (%60,`) to distinguish starting and ending `
-            // 2. escape | in %60...|...` (use while clause because in case of %60...|...|...`)
-            // 3. escape \|
-            row = row.replace(/`([^`]*?)`/g, '%60$1`');
-            while (/%60([^`]*?)\|([^`]*?)`/.test(row)) {
-                row = row.replace(/%60([^`]*?)\|([^`]*?)`/, '%60$1%7c$2`');
-            }
-            row = row.replace(/\\\|/g, '\\%7c');
-            return row.trim().replace(/^\|/g, '').replace(/\|$/g, '').trim().split(/\s*\|\s*/g).map(cell => {
-                return cell.replace(/%7c/g, '|').replace(/%60/g, '`');
-            });
-        });
-        // Normalize the num of hyphen
-        content[1] = content[1].map(cell => {
-            if (/:-+:/.test(cell)) {
-                return ':---:';
-            } else if (/:-+/.test(cell)) {
-                return ':---';
-            } else if (/-+:/.test(cell)) {
-                return '---:';
-            } else if (/-+/.test(cell)) {
-                return '---';
-            }
-        });
-        let colWidth = Array(content[0].length).fill(3);
+    /**
+     * Get the normalized indentation of a table as multiple of the configured `tabSize`.
+     * The indentation is only read from the first line and normalized to the closest tab stop.
+     */
+    private getNormalizedIndentation(text: string, options: FormattingOptions) {
+        let indentRegex = new RegExp(/^(\s*)\S/u)
+        let match = text.match(indentRegex)
+        let indent = match[1].length
+        let tabStops = Math.round(indent / options.tabSize)
+
+        return " ".repeat(options.tabSize * tabStops)
+    }
+
+    private formatTable(text: string, doc: TextDocument, options: FormattingOptions) {
+        let indentation = this.getNormalizedIndentation(text, options)
+
+        let rows = []
+        let rowsNoIndentPattern = new RegExp(/^\s*(\S.*)$/gum)
+        let match = null
+        while ((match = rowsNoIndentPattern.exec(text)) !== null) {
+            rows.push(match[1])
+        }
+        // Get all cell contents, also for ugly format (no trailing |)
+        let fieldRegExp = new RegExp(/(?:\|?((?:\\\||\\\\\||`.*?`|[^\|])*)\|)|(?:\|?((?:\\\||\\\\\||`.*?`|[^\|])+))/gu)
+
+        let colWidth = []
         let cn = /[\u3000-\u9fff\uff01-\uff60‘“’”—]/g;
-        content.forEach(row => {
-            row.forEach((cell, i) => {
-                // Treat Chinese characters as 2 English characters
-                let cellLength = cell.length;
-                if (cn.test(cell)) {
-                    cellLength += cell.match(cn).length;
+
+        let lines = rows.map(row => {
+            let field = null
+            let values = []
+            let i = 0
+            while ((field = fieldRegExp.exec(row)) !== null) {
+                let cell = null
+                if (field[1] === undefined) {
+                    if (field[2] !== undefined && field[2].trim().length > 0) {
+                        cell = field[2].trim()
+                    } else {
+                        continue;
+                    }
+                } else {
+                    cell = field[1].trim()
                 }
-                if (colWidth[i] < cellLength) {
-                    colWidth[i] = cellLength;
-                }
-            });
+                values.push(cell)
+                // Treat Chinese characters as 2 English ones because of Unicode stuff
+                let length = cn.test(cell) ? cell.length + cell.match(cn).length : cell.length
+                colWidth[i] = colWidth[i] > length ? colWidth[i] : length
+
+                i = i + 1
+            }
+            return (values)
         });
-        // Format
-        content[1] = content[1].map((cell, i) => {
-            if (cell == ':---:') {
+
+        // Normalize the num of hyphen        
+        lines[1] = lines[1].map((cell, i) => {
+            if (/:-+:/.test(cell)) {
+                //:---:
                 return ':' + '-'.repeat(colWidth[i] - 2) + ':';
-            } else if (cell == ':---') {
+            } else if (/:-+/.test(cell)) {
+                //:---
                 return ':' + '-'.repeat(colWidth[i] - 1);
-            } else if (cell == '---:') {
+            } else if (/-+:/.test(cell)) {
+                //---:
                 return '-'.repeat(colWidth[i] - 1) + ':';
-            } else if (cell == '---') {
+            } else if (/-+/.test(cell)) {
+                //---
                 return '-'.repeat(colWidth[i]);
             }
         });
-        return content.map(row => {
+
+        return lines.map(row => {
             let cells = row.map((cell, i) => {
                 let cellLength = colWidth[i];
                 if (cn.test(cell)) {
@@ -101,7 +118,7 @@ class MarkdownDocumentFormatter implements DocumentFormattingEditProvider {
                 }
                 return (cell + ' '.repeat(cellLength)).slice(0, cellLength);
             });
-            return '| ' + cells.join(' | ') + ' |';
+            return indentation + '| ' + cells.join(' | ') + ' |';
         }).join(workspace.getConfiguration('files', doc.uri).get('eol'));
     }
 }

--- a/test/listEditing.test.ts
+++ b/test/listEditing.test.ts
@@ -70,7 +70,17 @@ suite("List editing.", () => {
     });
 
     test("Backspace key. Fix ordered marker. 2", done => {
-        testCommand('markdown.extension.onBackspaceKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['1. item1', '    5. item2'], new Selection(1, 7, 1, 7), ['1. item1', '2. item2'], new Selection(1, 3, 1, 3)).then(done, done);
+        testCommand('markdown.extension.onBackspaceKey', { "editor.insertSpaces": true, "editor.tabSize": 4 },
+            [
+                '1. item1',
+                '    5. item2'
+            ],
+            new Selection(1, 7, 1, 7),
+            [
+                '1. item1',
+                '2. item2'
+            ],
+            new Selection(1, 3, 1, 3)).then(done, done);
     });
 
     test("Backspace key. Fix ordered marker. 3", done => {
@@ -79,13 +89,16 @@ suite("List editing.", () => {
                 '1. item1',
                 '    1. item1-1',
                 '    2. item1-2',
-                '    3. item1-3'],
+                '    3. item1-3',
+                '    4. item1-4'
+            ],
             new Selection(3, 7, 3, 7),
             [
                 '1. item1',
                 '    1. item1-1',
                 '    2. item1-2',
-                '2. item1-3'
+                '2. item1-3',
+                '    1. item1-4'
             ],
             new Selection(3, 3, 3, 3)).then(done, done);
     });
@@ -116,14 +129,16 @@ suite("List editing.", () => {
                 '1. test',
                 '    1. test',
                 '    2. test',
-                '2. test'
+                '2. test',
+                '    1. test'
             ],
             new Selection(3, 3, 3, 3),
             [
                 '1. test',
                 '    1. test',
                 '    2. test',
-                '    3. test'
+                '    3. test',
+                '    4. test'
             ],
             new Selection(3, 7, 3, 7)).then(done, done);
     });

--- a/test/listEditing.test.ts
+++ b/test/listEditing.test.ts
@@ -65,6 +65,18 @@ suite("List editing.", () => {
         testCommand('markdown.extension.onBackspaceKey', {}, ['- [ ]  item1'], new Selection(0, 7, 0, 7), ['- [ ] item1'], new Selection(0, 6, 0, 6)).then(done, done);
     });
 
+    test("Backspace key. 5: '    1. |'", done => {
+        testCommand('markdown.extension.onBackspaceKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['    1. item1'], new Selection(0, 7, 0, 7), ['1. item1'], new Selection(0, 3, 0, 3)).then(done, done);
+    });
+
+    test("Backspace key. 6: '    5. |'", done => {
+        testCommand('markdown.extension.onBackspaceKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['1. item1', '    5. item2'], new Selection(1, 7, 1, 7), ['1. item1', '2. item2'], new Selection(1, 3, 1, 3)).then(done, done);
+    });
+
+    test("Backspace key. 7: '    3. |'", done => {
+        testCommand('markdown.extension.onBackspaceKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['1. item1', '    1. item1-1', '    2. item1-2', '    3. item1-3'], new Selection(3, 7, 3, 7), ['1. item1', '    1. item1-1', '    2. item1-2', '2. item1-3'], new Selection(3, 3, 3, 3)).then(done, done);
+    });
+
     test("Tab key. 1: '- |'", done => {
         testCommand('markdown.extension.onTabKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['- item1'], new Selection(0, 2, 0, 2), ['    - item1'], new Selection(0, 6, 0, 6)).then(done, done);
     });
@@ -75,5 +87,41 @@ suite("List editing.", () => {
 
     test("Tab key. 3: '- [ ] |'", done => {
         testCommand('markdown.extension.onTabKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['- [ ] item1'], new Selection(0, 6, 0, 6), ['    - [ ] item1'], new Selection(0, 10, 0, 10)).then(done, done);
+    });
+
+    test("Tab key. 4: '2. |'", done => {
+        testCommand('markdown.extension.onTabKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['2. item1'], new Selection(0, 3, 0, 3), ['    1. item1'], new Selection(0, 7, 0, 7)).then(done, done);
+    });
+
+    test("Tab key. 5: '2.  |'", done => {
+        testCommand('markdown.extension.onTabKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['2.  item1'], new Selection(0, 3, 0, 3), ['    1.  item1'], new Selection(0, 7, 0, 7)).then(done, done);
+    });
+
+    test("Tab key. 6: '2. [ ] |'", done => {
+        testCommand('markdown.extension.onTabKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['2. [ ] item1'], new Selection(0, 7, 0, 7), ['    1. [ ] item1'], new Selection(0, 11, 0, 11)).then(done, done);
+    });
+
+    test("Move Line Up. 1: '2. |'", done => {
+        testCommand('markdown.extension.onMoveLineUp', {}, ['1. item1','2. item2'], new Selection(1, 3, 1, 3), ['1. item2','2. item1'], new Selection(0, 3, 0, 3)).then(done, done);
+    });
+
+    test("Move Line Up. 2: '2.  |'", done => {
+        testCommand('markdown.extension.onMoveLineUp', {}, ['1.  item1','2.  item2'], new Selection(1, 3, 1, 3), ['1.  item2','2.  item1'], new Selection(0, 3, 0, 3)).then(done, done);
+    });
+
+    test("Move Line Up. 3: '2. [ ] |'", done => {
+        testCommand('markdown.extension.onMoveLineUp', {}, ['1. [ ] item1','2. [ ] item2'], new Selection(1, 0, 1, 0), ['1. [ ] item2','2. [ ] item1'], new Selection(0, 0, 0, 0)).then(done, done);
+    });
+
+    test("Move Line Down. 1: '1. |'", done => {
+        testCommand('markdown.extension.onMoveLineDown', {}, ['1. item1','2. item2'], new Selection(0, 3, 0, 3), ['1. item2','2. item1'], new Selection(1, 3, 1, 3)).then(done, done);
+    });
+
+    test("Move Line Down. 2: '1.  |'", done => {
+        testCommand('markdown.extension.onMoveLineDown', {}, ['1.  item1','2.  item2'], new Selection(0, 3, 0, 3), ['1.  item2','2.  item1'], new Selection(1, 3, 1, 3)).then(done, done);
+    });
+
+    test("Move Line Down. 3: '1. [ ] |'", done => {
+        testCommand('markdown.extension.onMoveLineDown', {}, ['1. [ ] item1','2. [ ] item2'], new Selection(0, 0, 0, 0), ['1. [ ] item2','2. [ ] item1'], new Selection(1, 0, 1, 0)).then(done, done);
     });
 });

--- a/test/listEditing.test.ts
+++ b/test/listEditing.test.ts
@@ -3,7 +3,7 @@ import { testMdFile, defaultConfigs, testCommand } from './testUtils';
 
 suite("List editing.", () => {
     suiteSetup(async () => {
-        // 💩 Preload file to prevent the first test to be treated timeout
+        // 💩 Preload file to prevent the first test timeout
         await workspace.openTextDocument(testMdFile);
 
         for (let key in defaultConfigs) {
@@ -65,16 +65,29 @@ suite("List editing.", () => {
         testCommand('markdown.extension.onBackspaceKey', {}, ['- [ ]  item1'], new Selection(0, 7, 0, 7), ['- [ ] item1'], new Selection(0, 6, 0, 6)).then(done, done);
     });
 
-    test("Backspace key. 5: '    1. |'", done => {
+    test("Backspace key. Fix ordered marker. 1", done => {
         testCommand('markdown.extension.onBackspaceKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['    1. item1'], new Selection(0, 7, 0, 7), ['1. item1'], new Selection(0, 3, 0, 3)).then(done, done);
     });
 
-    test("Backspace key. 6: '    5. |'", done => {
+    test("Backspace key. Fix ordered marker. 2", done => {
         testCommand('markdown.extension.onBackspaceKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['1. item1', '    5. item2'], new Selection(1, 7, 1, 7), ['1. item1', '2. item2'], new Selection(1, 3, 1, 3)).then(done, done);
     });
 
-    test("Backspace key. 7: '    3. |'", done => {
-        testCommand('markdown.extension.onBackspaceKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['1. item1', '    1. item1-1', '    2. item1-2', '    3. item1-3'], new Selection(3, 7, 3, 7), ['1. item1', '    1. item1-1', '    2. item1-2', '2. item1-3'], new Selection(3, 3, 3, 3)).then(done, done);
+    test("Backspace key. Fix ordered marker. 3", done => {
+        testCommand('markdown.extension.onBackspaceKey', { "editor.insertSpaces": true, "editor.tabSize": 4 },
+            [
+                '1. item1',
+                '    1. item1-1',
+                '    2. item1-2',
+                '    3. item1-3'],
+            new Selection(3, 7, 3, 7),
+            [
+                '1. item1',
+                '    1. item1-1',
+                '    2. item1-2',
+                '2. item1-3'
+            ],
+            new Selection(3, 3, 3, 3)).then(done, done);
     });
 
     test("Tab key. 1: '- |'", done => {
@@ -89,39 +102,53 @@ suite("List editing.", () => {
         testCommand('markdown.extension.onTabKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['- [ ] item1'], new Selection(0, 6, 0, 6), ['    - [ ] item1'], new Selection(0, 10, 0, 10)).then(done, done);
     });
 
-    test("Tab key. 4: '2. |'", done => {
+    test("Tab key. Fix ordered marker. 1", done => {
         testCommand('markdown.extension.onTabKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['2. item1'], new Selection(0, 3, 0, 3), ['    1. item1'], new Selection(0, 7, 0, 7)).then(done, done);
     });
 
-    test("Tab key. 5: '2.  |'", done => {
-        testCommand('markdown.extension.onTabKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['2.  item1'], new Selection(0, 3, 0, 3), ['    1.  item1'], new Selection(0, 7, 0, 7)).then(done, done);
-    });
-
-    test("Tab key. 6: '2. [ ] |'", done => {
+    test("Tab key. Fix ordered marker. 2", done => {
         testCommand('markdown.extension.onTabKey', { "editor.insertSpaces": true, "editor.tabSize": 4 }, ['2. [ ] item1'], new Selection(0, 7, 0, 7), ['    1. [ ] item1'], new Selection(0, 11, 0, 11)).then(done, done);
     });
 
+    test("Tab key. Fix ordered marker. 3", done => {
+        testCommand('markdown.extension.onTabKey', { "editor.insertSpaces": true, "editor.tabSize": 4 },
+            [
+                '1. test',
+                '    1. test',
+                '    2. test',
+                '2. test'
+            ],
+            new Selection(3, 3, 3, 3),
+            [
+                '1. test',
+                '    1. test',
+                '    2. test',
+                '    3. test'
+            ],
+            new Selection(3, 7, 3, 7)).then(done, done);
+    });
+
     test("Move Line Up. 1: '2. |'", done => {
-        testCommand('markdown.extension.onMoveLineUp', {}, ['1. item1','2. item2'], new Selection(1, 3, 1, 3), ['1. item2','2. item1'], new Selection(0, 3, 0, 3)).then(done, done);
+        testCommand('markdown.extension.onMoveLineUp', {}, ['1. item1', '2. item2'], new Selection(1, 3, 1, 3), ['1. item2', '2. item1'], new Selection(0, 3, 0, 3)).then(done, done);
     });
 
     test("Move Line Up. 2: '2.  |'", done => {
-        testCommand('markdown.extension.onMoveLineUp', {}, ['1.  item1','2.  item2'], new Selection(1, 3, 1, 3), ['1.  item2','2.  item1'], new Selection(0, 3, 0, 3)).then(done, done);
+        testCommand('markdown.extension.onMoveLineUp', {}, ['1.  item1', '2.  item2'], new Selection(1, 3, 1, 3), ['1.  item2', '2.  item1'], new Selection(0, 3, 0, 3)).then(done, done);
     });
 
     test("Move Line Up. 3: '2. [ ] |'", done => {
-        testCommand('markdown.extension.onMoveLineUp', {}, ['1. [ ] item1','2. [ ] item2'], new Selection(1, 0, 1, 0), ['1. [ ] item2','2. [ ] item1'], new Selection(0, 0, 0, 0)).then(done, done);
+        testCommand('markdown.extension.onMoveLineUp', {}, ['1. [ ] item1', '2. [ ] item2'], new Selection(1, 0, 1, 0), ['1. [ ] item2', '2. [ ] item1'], new Selection(0, 0, 0, 0)).then(done, done);
     });
 
     test("Move Line Down. 1: '1. |'", done => {
-        testCommand('markdown.extension.onMoveLineDown', {}, ['1. item1','2. item2'], new Selection(0, 3, 0, 3), ['1. item2','2. item1'], new Selection(1, 3, 1, 3)).then(done, done);
+        testCommand('markdown.extension.onMoveLineDown', {}, ['1. item1', '2. item2'], new Selection(0, 3, 0, 3), ['1. item2', '2. item1'], new Selection(1, 3, 1, 3)).then(done, done);
     });
 
     test("Move Line Down. 2: '1.  |'", done => {
-        testCommand('markdown.extension.onMoveLineDown', {}, ['1.  item1','2.  item2'], new Selection(0, 3, 0, 3), ['1.  item2','2.  item1'], new Selection(1, 3, 1, 3)).then(done, done);
+        testCommand('markdown.extension.onMoveLineDown', {}, ['1.  item1', '2.  item2'], new Selection(0, 3, 0, 3), ['1.  item2', '2.  item1'], new Selection(1, 3, 1, 3)).then(done, done);
     });
 
     test("Move Line Down. 3: '1. [ ] |'", done => {
-        testCommand('markdown.extension.onMoveLineDown', {}, ['1. [ ] item1','2. [ ] item2'], new Selection(0, 0, 0, 0), ['1. [ ] item2','2. [ ] item1'], new Selection(1, 0, 1, 0)).then(done, done);
+        testCommand('markdown.extension.onMoveLineDown', {}, ['1. [ ] item1', '2. [ ] item2'], new Selection(0, 0, 0, 0), ['1. [ ] item2', '2. [ ] item1'], new Selection(1, 0, 1, 0)).then(done, done);
     });
 });

--- a/test/tableFormatter.test.ts
+++ b/test/tableFormatter.test.ts
@@ -180,4 +180,22 @@ suite("Table formatter.", () => {
             ],
             new Selection(0, 0, 0, 0)).then(done, done)
     });
+
+    test("Contains \\| in last open cell", done => {
+        testCommand('editor.action.formatDocument', {},
+            [
+                '', // Changing the first expected char somehow crashes the selection logic and the test fails
+                'a|b', 
+                '---|---',
+                'c|d\\|e'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '',
+                '| a   | b    |',
+                '| --- | ---- |',
+                '| c   | d\\|e |'
+            ],
+            new Selection(0, 0, 0, 0)).then(done, done);
+    });
 });

--- a/test/tableFormatter.test.ts
+++ b/test/tableFormatter.test.ts
@@ -118,4 +118,66 @@ suite("Table formatter.", () => {
             ],
             new Selection(0, 0, 0, 0)).then(done, done);
     });
+
+    test("No table", done => {
+        testCommand('editor.action.formatDocument', {},
+            [
+                'a | b',
+                '---'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                'a | b',
+                '---'
+            ],
+            new Selection(0, 0, 0, 0)).then(done, done)
+    });
+
+    test("Indented table", done => {
+        testCommand('editor.action.formatDocument', {},
+            [
+                '    | a | b |',
+                '    | --- | --- |',
+                '    | c | d |'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '    | a   | b   |',
+                '    | --- | --- |',
+                '    | c   | d   |'
+            ],
+            new Selection(0, 0, 0, 0)).then(done, done)
+    });
+
+    test("Mixed-indented table", done => {
+        testCommand('editor.action.formatDocument', {},
+            [
+                '   | a | b |',
+                '  | --- | --- |',
+                '    | c | d |'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '    | a   | b   |',
+                '    | --- | --- |',
+                '    | c   | d   |'
+            ],
+            new Selection(0, 0, 0, 0)).then(done, done)
+    });
+
+    test("Mixed ugly table", done => {
+        testCommand('editor.action.formatDocument', {},
+            [
+                '| a | b | c ',
+                ' --- | --- | :---:',
+                ' c | d | e |'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '| a   | b   | c     |',
+                '| --- | --- | :---: |',
+                '| c   | d   | e     |'
+            ],
+            new Selection(0, 0, 0, 0)).then(done, done)
+    });
 });

--- a/test/tableFormatter.test.ts
+++ b/test/tableFormatter.test.ts
@@ -149,8 +149,26 @@ suite("Table formatter.", () => {
             new Selection(0, 0, 0, 0)).then(done, done)
     });
 
-    test("Mixed-indented table", done => {
-        testCommand('editor.action.formatDocument', {},
+    test("Mixed-indented table (no normalization)", done => {
+        testCommand('editor.action.formatDocument',
+            { "markdown.extension.tableFormatter.normalizeIndentation": false },
+            [
+                '   | a | b |',
+                '  | --- | --- |',
+                '    | c | d |'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '   | a   | b   |',
+                '   | --- | --- |',
+                '   | c   | d   |'
+            ],
+            new Selection(0, 0, 0, 0)).then(done, done)
+    });
+
+    test("Mixed-indented table (normalization)", done => {
+        testCommand('editor.action.formatDocument',
+            { "markdown.extension.tableFormatter.normalizeIndentation": true },
             [
                 '   | a | b |',
                 '  | --- | --- |',
@@ -185,7 +203,7 @@ suite("Table formatter.", () => {
         testCommand('editor.action.formatDocument', {},
             [
                 '', // Changing the first expected char somehow crashes the selection logic and the test fails
-                'a|b', 
+                'a|b',
                 '---|---',
                 'c|d\\|e'
             ],


### PR DESCRIPTION
I meant to reduce the complexity of table formatting a lot by using
clever regex - I did not succeed fully here, but there are some
improvements from my point of view:

- additional tests
- indented tables are working (fixes #107)
- dash-lines (`---`) are not recognised as tables anymore by mistake
- no additional loop for the cell lengths