### PR TITLE
Add markdown.extension.toc.tabSize setting in order to comply with MD007

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,11 @@
                     "default": false,
                     "description": "%config.toc.githubCompatibility.description%"
                 },
+                "markdown.extension.toc.tabSize": {
+                    "type": ["number", "string"],
+                    "default": "auto",
+                    "description": "%config.toc.tabSize.description%"
+                },
                 "markdown.extension.preview.autoShowPreviewToSide": {
                     "type": "boolean",
                     "default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -14,6 +14,7 @@
     "config.toc.plaintext.description": "Just plain text",
     "config.toc.updateOnSave.description": "Auto update on save",
     "config.toc.githubCompatibility.description": "GitHub Compatibility",
+    "config.toc.tabSize.description": "Number of spaces for toc indentation. With 'auto', it is set to 2 for unordered list toc (MD007 convention) and 3 for unordered list toc (no convention)",
     "config.preview.autoShowPreviewToSide.description": "Auto show preview to side",
     "config.orderedList.marker.description": "`one`: always use `1.` as ordered list marker; `ordered`",
     "config.orderedList.autoRenumber.description": "Auto fix ordered list markers",

--- a/src/toc.ts
+++ b/src/toc.ts
@@ -6,8 +6,8 @@ import { extractText, isMdEditor, mdDocSelector, slugify } from './util';
 /**
  * Workspace config
  */
-let docConfig = { tab: '    ', eol: '\r\n' };
-let tocConfig = { startDepth: 1, endDepth: 6, listMarker: '-', orderedList: false, updateOnSave: false, plaintext: false };
+let docConfig = { tab: '  ', eol: '\r\n' };
+let tocConfig = { startDepth: 1, endDepth: 6, listMarker: '-', orderedList: false, updateOnSave: false, plaintext: false, tabSize: 2 };
 
 export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
@@ -204,11 +204,13 @@ function loadTocConfig() {
     // Load workspace config
     let activeEditor = vscode.window.activeTextEditor;
     docConfig.eol = activeEditor.document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n';
-    let tabSize = Number(activeEditor.options.tabSize);
+    let tabSize = tocSectionCfg.get<number | 'auto'>('tabSize');
     let insertSpaces = activeEditor.options.insertSpaces;
 
-    docConfig.tab = '\t';
-    if (insertSpaces && tabSize > 0) {
+    
+    if (tabSize === "auto") {
+        docConfig.tab = insertSpaces ? " ".repeat(tocConfig.orderedList ? 3 : 2) : '\t';
+    } else {
         docConfig.tab = " ".repeat(tabSize);
     }
 }

--- a/test/toc.test.ts
+++ b/test/toc.test.ts
@@ -43,7 +43,7 @@ suite("TOC.", () => {
                 '# Section 2',
                 '',
                 '- [Section 1](#section-1)',
-                '    - [Section 1.1](#section-11)',
+                '  - [Section 1.1](#section-11)',
                 '- [Section 2](#section-2)'
             ],
             new Selection(8, 25, 8, 25)).then(done, done);
@@ -61,7 +61,7 @@ suite("TOC.", () => {
                 '## Section 2.1',
                 '',
                 '- [Section 1](#section-1)',
-                '    - [Section 1.1](#section-11)',
+                '  - [Section 1.1](#section-11)',
                 '- [Section 2](#section-2)'
             ],
             new Selection(0, 0, 0, 0),
@@ -75,9 +75,9 @@ suite("TOC.", () => {
                 '## Section 2.1',
                 '',
                 '- [Section 1](#section-1)',
-                '    - [Section 1.1](#section-11)',
+                '  - [Section 1.1](#section-11)',
                 '- [Section 2](#section-2)',
-                '    - [Section 2.1](#section-21)'
+                '  - [Section 2.1](#section-21)'
             ],
             new Selection(0, 0, 0, 0)).then(done, done);
     });
@@ -125,11 +125,11 @@ suite("TOC.", () => {
                 '#### Section 2.1.1.1',
                 '',
                 '- [Section 1.1](#section-11)',
-                '    - [Section 1.1.1](#section-111)',
+                '  - [Section 1.1.1](#section-111)',
                 '- [Section 2.1](#section-21)',
-                '    - [Section 2.1.1](#section-211)',
+                '  - [Section 2.1.1](#section-211)',
             ],
-            new Selection(19, 35, 19, 35)).then(done, done);
+            new Selection(19, 33, 19, 33)).then(done, done);
     });
 
     test("Update (levels 2..3)", done => {
@@ -151,9 +151,9 @@ suite("TOC.", () => {
                 '## Section 2.1',
                 '',
                 '- [Section 1.1](#section-11)',
-                '    - [Section 1.1.1](#section-111)',
+                '  - [Section 1.1.1](#section-111)',
                 '- [Section 2.1](#section-21)',
-                '    - [Section 2.1.1](#section-211)',
+                '  - [Section 2.1.1](#section-211)',
             ],
             new Selection(0, 0, 0, 0),
             [
@@ -170,7 +170,7 @@ suite("TOC.", () => {
                 '## Section 2.1',
                 '',
                 '- [Section 1.1](#section-11)',
-                '    - [Section 1.1.1](#section-111)',
+                '  - [Section 1.1.1](#section-111)',
                 '- [Section 2.1](#section-21)'
             ],
             new Selection(0, 0, 0, 0)).then(done, done);
@@ -196,7 +196,7 @@ suite("TOC.", () => {
                 '# Section 2',
                 '',
                 '- [Section 中文](#section-%E4%B8%AD%E6%96%87)',
-                '    - [Section 1.1](#section-11)',
+                '  - [Section 1.1](#section-11)',
                 '- [Section 2](#section-2)'
             ],
             new Selection(8, 25, 8, 25)).then(done, done);
@@ -238,9 +238,9 @@ suite("TOC.", () => {
                 '---',
                 '',
                 '- [Section 1](#section-1)',
-                '    - [Section 1.1](#section-11)'
+                '  - [Section 1.1](#section-11)'
             ],
-            new Selection(7, 32, 7, 32)).then(done, done);
+            new Selection(7, 30, 7, 30)).then(done, done);
     });
 
     test("Non-Latin symbols", done => {
@@ -262,8 +262,8 @@ suite("TOC.", () => {
                 '## Секция 1.1',
                 '',
                 '- [Секция 1](#Секция-1)',
-                '    - [Секция 1.1](#Секция-11)'
+                '  - [Секция 1.1](#Секция-11)'
             ],
-            new Selection(5, 30, 5, 30)).then(done, done);
+            new Selection(5, 28, 5, 28)).then(done, done);
     });
 });


### PR DESCRIPTION
Unordered lists are (by convention of [MD007]) supposed to be indented using 2 spaces.

⚠ WARNING ⚠: By default, I chose to **set the tabSize to 2** so that MD007 is fulfilled, which is different from the current behavior (which uses the `editor.tabSize`)

This PR is a quickfix for that issue; we should (later?) consider a better solution that includes picking up the configuration from [vscode-markdownlint](https://github.com/DavidAnson/vscode-markdownlint) as detailed in #155.

[MD007]: https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md007

Related issues: #77, #155, #198